### PR TITLE
feat: add anchor links to titles

### DIFF
--- a/book.json
+++ b/book.json
@@ -2,7 +2,7 @@
     "styles": {
         "website": "styles/website.css"
     },
-    "plugins": [ "theme-api"],
+    "plugins": [ "theme-api", "anchors"],
     "pluginsConfig": {
         "theme-api": {
             "languages": [


### PR DESCRIPTION
This PR includes the`anchors` plugin, which adds a handy anchor icon to titles on hover:

![screen shot 2018-06-15 at 07 23 27](https://user-images.githubusercontent.com/4419992/41463510-20a9fea6-706d-11e8-92a5-cf3e3dedb331.png)

I personally consider anchor links a must-have feature of any documentation page, because it makes way easier to point to a special section of the docs, which can be useful for users and specially for us when assisting users.

ps: Don't forget to run `yarn gb-install`!
