### PR TITLE
fix: s/Haiku/Animator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 ---
-description: The Haiku docs are your one stop shop for everything you need to know about Haiku. Learn about what Haiku is, who it's for and why you or your team might use it.
+description: The Haiku Animator docs are your one stop shop for everything you need to know about Animator. Learn about what Animator is, who it's for and why you or your team might use it.
 ---
 
 <br>
 
-# Welcome to the Haiku Docs !
+# Welcome to the Haiku Animator Docs !
 
-Welcome! Everything new and advanced users want to know about Haiku should be available in the Docs. If you're brand new to Haiku check out our [Getting Started](http://docs.haiku.ai/getting-started.html) page or the rest of our learning resources (like tutorials and support) on the [Learn page](http://haiku.ai/learn).
+Welcome! Everything new and advanced users want to know about Animator should be available in the Docs. If you're brand new to Animator check out our [Getting Started](http://docs.haiku.ai/getting-started.html) page or the rest of our learning resources (like tutorials and support) on the [Learn page](http://haiku.ai/learn).
 
 
 #### Most Popular Documents
 
 [Importing Sketch and Other Image Assets](http://docs.haiku.ai/using-haiku/sketch-and-image-assets.html)
 
-[Advanced: Editing Haiku as Code](http://docs.haiku.ai/using-haiku/advanced-editing-haiku-as-code.html)
+[Advanced: Editing Animator projects as Code](http://docs.haiku.ai/using-haiku/advanced-editing-haiku-as-code.html)
 
 [Creating Animations with the Timeline](http://docs.haiku.ai/using-haiku/creating-an-animation.html)
 
-[Summonables in Haiku](http://docs.haiku.ai/using-haiku/summonables.html)
+[Summonables in Haiku Animator](http://docs.haiku.ai/using-haiku/summonables.html)
 
 [Publishing and Embedding](http://docs.haiku.ai/embedding-and-using-haiku/publishing-and-embedding.html)
 
@@ -29,4 +29,4 @@ Everything else in the Docs is navigable from the left hand menu or searchable i
 
 
 
-[Next: What is Haiku](what-is-haiku.md) &rarr;
+[Next: What is Haiku Animator](what-is-haiku.md) &rarr;

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,14 +1,14 @@
 # Table of Contents
 
 * [Welcome](README.md)
-* [What is Haiku](what-is-haiku.md)
+* [What is Haiku Animator](what-is-haiku.md)
 * [Getting Started](getting-started.md)
 
 
 
-## Creating Content with Haiku
+## Creating Content with Haiku Animator
 
-* [Starting Haiku](using-haiku/starting-haiku.md)
+* [Starting Haiku Animator](using-haiku/starting-haiku.md)
 * [Importing Sketch & Other Image Assets](using-haiku/sketch-and-image-assets.md)
 * [Importing Figma Projects](using-haiku/importing-figma-projects.md)
 * [Editing Elements on the Stage](using-haiku/editing-elements-on-the-stage.md)
@@ -25,16 +25,16 @@
 * [Reusable Components](/using-haiku/reusable-components.md)
 * [Communicating between Components](/using-haiku/communicating-components.md)
 
-## Embedding Haiku Components
+## Embedding Animator Components
 
 * [Haiku Core Overview](embedding-and-using-haiku/haiku-core-overview.md)
 * [Publishing, Embedding and Forking](embedding-and-using-haiku/publishing-and-embedding.md)
 * [iOS & Android powered by Lottie](embedding-and-using-haiku/lottie.md)
 
-## Haiku for Developers
+## Animator for Developers
 
-* [Using the Haiku CLI](using-haiku/using-the-cli.md)
-* [Haiku Developer API](embedding-and-using-haiku/haiku-core-api.md)
+* [Using the Haiku Animator CLI](using-haiku/using-the-cli.md)
+* [Haiku Animator Developer API](embedding-and-using-haiku/haiku-core-api.md)
 * [Editing Haiku as Code](using-haiku/advanced-editing-haiku-as-code.md)
 * [Version Control](using-haiku/advanced-version-control.md)
 

--- a/_layouts/website/summary.html
+++ b/_layouts/website/summary.html
@@ -33,12 +33,12 @@ https://github.com/GitbookIO/theme-api/commit/306cd2b746d041e71bf609ed534c27a34e
      {% endfor %}
  {% endmacro %}
 
- <a href="https://www.haiku.ai" target="_blank" class="go-to-www">
-   <img src="/assets/exit-left.svg" class="exit-left" alt="Go to Haiku.ai">
-   <span>Go to haiku.ai</span>
+ <a href="https://www.haikuforteams.com/" target="_blank" class="go-to-www">
+   <img src="/assets/exit-left.svg" class="exit-left" alt="Go to Animator webpage">
+   <span>Go to Haiku for Teams</span>
  </a>
 
- <img src="/assets/docs-logo.svg" class="docs-logo" alt="Haiku Docs Logo">
+ <img src="/assets/docs-logo.svg" class="docs-logo" alt="Animator Docs Logo">
 
  <ul class="summary">
      {% set _divider = false %}

--- a/embedding-and-using-haiku/haiku-core-api.md
+++ b/embedding-and-using-haiku/haiku-core-api.md
@@ -4,13 +4,13 @@
 
 #### OVERVIEW {#overview}
 
-A programmatic interface to the Haiku Core (and your published Haiku) is available for those who need more control. With the programmatic API, you can access your Haiku's internal content and create fine-grained behavior that responds to user and page events.
+A programmatic interface to the Haiku Core (and your published project) is available for those who need more control. With the programmatic API, you can access your project's internal content and create fine-grained behavior that responds to user and page events.
 
 <br>
 
 #### EMBED API {#embedapi}
 
-The first interface to control your Haiku is via its declarative embedding API. (Getting your embed snippet is covered in the [embedding section](/embedding-and-using-haiku/publishing-and-embedding.md).)
+The first interface to control your project is via its declarative embedding API. (Getting your embed snippet is covered in the [embedding section](/embedding-and-using-haiku/publishing-and-embedding.md).)
 
 <br>
 
@@ -18,7 +18,7 @@ The first interface to control your Haiku is via its declarative embedding API. 
 
 The first thing you might want to do is override the [states](/using-haiku/defining-states.md) you've defined.
 
-For example, if you are embedding a Haiku as a React component, you can override its internal states by passing a `haikuStates` prop. (Note: It is best to think of Haiku states as a combination of React's `this.state` and `this.props`, since internally the Haiku Core treats them the same.)
+For example, if you are embedding a project as a React component, you can override its internal states by passing a `haikuStates` prop. (Note: It is best to think of Animator states as a combination of React's `this.state` and `this.props`, since internally the Haiku Core treats them the same.)
 
 ```
 <MyHaiku
@@ -56,14 +56,14 @@ Haiku Core's behavior can be controlled by passing in lifecycle event handlers a
   onHaikuComponentWillUnmount: null,
 
   // contextMenu: String
-  // Whether the Haiku menu will display when the component is right-clicked;
+  // Whether the Animator menu will display when the component is right-clicked;
   // value may be 'enabled' or 'disabled'
   contextMenu: 'enabled',
 
   // mixpanel: String|Boolean
   // If provided, the component will transmit metadata to Mixpanel;
   // specify your own token here, or set to falsy to disable tracking altogether.
-  // We send only public information: your component's name, its Haiku account username,
+  // We send only public information: your component's name, its Animator account username,
   // the software version it was built with, and its share identifier.
   mixpanel: '{mixpanel api token}',
 
@@ -148,9 +148,9 @@ Haiku Core's behavior can be controlled by passing in lifecycle event handlers a
 
 **Passing in children &amp; using "placeholders"**
 
-You can pass child elements into your `<MyHaiku>` element to be inserted in place of elements that you have composed and orchestrated on stage. This is a great way to use Haiku to animate dynamic content.
+You can pass child elements into your `<MyHaiku>` element to be inserted in place of elements that you have composed and orchestrated on stage. This is a great way to use Animator to animate dynamic content.
 
-In [Haiku for Mac](https://haiku.ai), use the Timeline to add a `controlFlow.placeholder` property to any element on stage. Set the field's value to a CSS id selector, such as `#some-content`. Then, when embedding your `<MyHaiku>` in a React component, pass it a child element whose id matches that selector.
+In [Animator](https://www.haikuforteams.com/), use the Timeline to add a `controlFlow.placeholder` property to any element on stage. Set the field's value to a CSS id selector, such as `#some-content`. Then, when embedding your `<MyHaiku>` in a React component, pass it a child element whose id matches that selector.
 
 ```
 <MyHaiku>
@@ -270,7 +270,7 @@ You can also subscribe to custom events:
 
 ###### PROPERTIES
 
-* `state` (object) - An object of the state values held by this instance of your component. (These states are the same states you configure visually using the State Inspector in Haiku for Mac.)
+* `state` (object) - An object of the state values held by this instance of your component. (These states are the same states you configure visually using the State Inspector in Animator.)
 * `CORE_VERSION` (string) - The semver-based version of Haiku Core that is running this instance.
 * `config` (object) - The configuration settings for this instance.
 
@@ -280,7 +280,7 @@ You can also subscribe to custom events:
 
 > Note: As known as immediate `setState`
 
-Similar to React's API, `.setState` updates the states defined in the instance of your component. (These states are the same states you configure visually using the State Inspector in Haiku for Mac.) A state can be a `number`, `string`, `array`, `object`, or `null`. Example:
+Similar to React's API, `.setState` updates the states defined in the instance of your component. (These states are the same states you configure visually using the State Inspector in Animator.) A state can be a `number`, `string`, `array`, `object`, or `null`. Example:
 
 ```
 this.setState({
@@ -301,9 +301,9 @@ In addition to immediate `setState`, user has the option to set a state transiti
 
 
 ```
-this.setState({foo: 10}, 
+this.setState({foo: 10},
 {
-  duration: 1000, 
+  duration: 1000,
   curve: "easeInExpo",
   queue: true
 })
@@ -559,7 +559,7 @@ Haiku Core's API currently offers a familiar CSS-like querying system for locati
 * By id, e.g. `.querySelector('#foo')`
 * By class name, e.g. `.querySelector('.bar')`
 * Comma-separated lists of the above, .e.g `div, #foo, .bar`
-* By Haiku identifier, e.g. `.querySelector('haiku:abcde12345')`. (Note: this Haiku-specific extension is subject to revision in the future. As Haiku elements' identifiers are autogenerated in Haiku for Mac, use with care.)
+* By Haiku identifier, e.g. `.querySelector('haiku:abcde12345')`. (Note: this Haiku-specific extension is subject to revision in the future. As Haiku elements' identifiers are autogenerated in Animator for Mac, use with care.)
 
 **Not yet supported:**
 
@@ -571,4 +571,4 @@ We may support more CSS selector features if we hear from the community that the
 
 <br>
 
-[Next: Editing Haiku as Code](/using-haiku/advanced-editing-haiku-as-code.md) &rarr;
+[Next: Editing Animator projects as Code](/using-haiku/advanced-editing-haiku-as-code.md) &rarr;

--- a/embedding-and-using-haiku/haiku-core-overview.md
+++ b/embedding-and-using-haiku/haiku-core-overview.md
@@ -4,11 +4,9 @@
 
 #### OVERVIEW
 
-The Haiku Core is **NOT** a browser plugin.  It's simply a bundle of JavaScript that is included with your Haiku, allowing them to render on the web using the web's native technologies (HTML, CSS, JS).
+The Haiku Core is **NOT** a browser plugin.  It's simply a bundle of JavaScript that is included with your Animator project, allowing them to render on the web using the web's native technologies (HTML, CSS, JS).
 
-The means Haiku runs anywhere your code does, on any modern browser.
-
-In the simplest case, you don't even have to think about the "core" — we do the heavy lifting and provide the code snippets to include your Haiku in codebases of different kinds (see [Publishing and Embedding](/embedding-and-using-haiku/publishing-and-embedding.md)).  One line of code and done.
+In the simplest case, you don't even have to think about the "core" — we do the heavy lifting and provide the code snippets to include your project in codebases of different kinds (see [Publishing and Embedding](/embedding-and-using-haiku/publishing-and-embedding.md)).  One line of code and done.
 
 But sometimes you want more control: Maybe you want to control the timeline based on events, or change the way your component is sized inside its container  — or any number of [programmatic actions](/embedding-and-using-haiku/haiku-core-api.md).  For these cases, you can use the [Haiku Core Developer API](/embedding-and-using-haiku/haiku-core-api.md).
 

--- a/embedding-and-using-haiku/lottie.md
+++ b/embedding-and-using-haiku/lottie.md
@@ -1,12 +1,12 @@
 ---
-description: Use Haiku to author animations for Lottie, an open source iOS, Android, and React Native library.
+description: Use Haiku Animator to author animations for Lottie, an open source iOS, Android, and React Native library.
 ---
 
 # iOS & Android Rendering powered by Lottie
 
 #### OVERVIEW {#overview}
 
-[Lottie](https://airbnb.design/lottie/) is an open source iOS, Android, and React Native library from Airbnb that renders animations, allowing apps to use animations as easily as they use static images. Using Haiku, you can author Lottie compatible animations.
+[Lottie](https://airbnb.design/lottie/) is an open source iOS, Android, and React Native library from Airbnb that renders animations, allowing apps to use animations as easily as they use static images. Using Animator, you can author Lottie compatible animations.
 
 
 #### USING LOTTIE {#usage}
@@ -17,7 +17,7 @@ After [publishing](/embedding-and-using-haiku/publishing-and-embedding.md), sele
 
 #### SUPPORTED VERSIONS {#versions}
 
-Haiku has been tested with the following versions of Lottie:
+Animator has been tested with the following versions of Lottie:
 
 - **lottie-web**: 5.1.1+
 - **lottie-ios**: 2.1.4+
@@ -35,12 +35,12 @@ For **lottie-ios**, raster image support is available in the latest code checked
 
 Lottie does not support all features of After Effects; please refer to the [list of supported features](http://airbnb.io/lottie/supported-features.html) for details. Notable After Effects features lacking support on both Android and iOS include 3D rotation and shear.
 
-Dynamic Haiku features including [Expressions](../using-haiku/writing-expressions.md), [States](../using-haiku/defining-states.md), [Summonables](../using-haiku/summonables.md), or [Actions](../using-haiku/actions.md) will not translate to dynamic Lottie animations.
+Dynamic Haiku Animator features including [Expressions](../using-haiku/writing-expressions.md), [States](../using-haiku/defining-states.md), [Summonables](../using-haiku/summonables.md), or [Actions](../using-haiku/actions.md) will not translate to dynamic Lottie animations.
 
-Because Haiku components are typically created from scalable vector graphics (SVGs), which use many different conventions than After Effects shapes, you may notice some discrepancies between your Haiku rendered in a browser vs. Lottie. We are working closely with the Lottie team to bring our products closer together.
+Because Animator components are typically created from scalable vector graphics (SVGs), which use many different conventions than After Effects shapes, you may notice some discrepancies between your Animator project rendered in a browser vs. Lottie. We are working closely with the Lottie team to bring our products closer together.
 
 If you encounter any issues, or if you have any questions about Lottie, please contact us on [our community Slack](https://www.haiku.ai/slack-community) or [by email](mailto:contact@haiku.ai).
 
 <br>
 
-[Next: Using the Haiku CLI](/using-haiku/using-the-cli.md) &rarr;
+[Next: Using the Haiku Animator CLI](/using-haiku/using-the-cli.md) &rarr;

--- a/embedding-and-using-haiku/publishing-and-embedding.md
+++ b/embedding-and-using-haiku/publishing-and-embedding.md
@@ -1,5 +1,5 @@
 ---
-description: Learn about publishing and embedding your Haiku. The first step to getting your Haiku out into the world is to publish it. Simply press Publish and your up-to-the-moment work will be shuttled out to the cloud and packaged up for use in any codebase.
+description: Learn about publishing and embedding your Animator project. The first step to getting your Animator project out into the world is to publish it. Simply press Publish and your up-to-the-moment work will be shuttled out to the cloud and packaged up for use in any codebase.
 ---
 
 # Publishing and Embedding
@@ -7,7 +7,7 @@ description: Learn about publishing and embedding your Haiku. The first step to 
 
 #### PUBLISH BUTTON {#button}
 
-The first step to getting your Haiku out into the world is to _publish_ it.
+The first step to getting your Animator project out into the world is to _publish_ it.
 
 You'll find a button on the top-right of project editor that does just that.
 
@@ -23,9 +23,9 @@ Simply press PUBLISH and your up-to-the-moment work will be shuttled out to the 
 
 ![](/assets/publish-options.jpg)
 
-The shareable link will take you to your Haiku's Share Page: see below.
+The shareable link will take you to your project's Share Page: see below.
 
-Here you can also explore embed options for your Haiku, which are also mirrored on your Share page.
+Here you can also explore embed options for your project, which are also mirrored on your Share page.
 
 > _Note on publish speed_: Depending on your connection speed and place in the world, publishing can currently take a little while, between 5 seconds and 2 minutes.  We're working on making this faster.  Once when we have realtime collaboration hooked up, publishing should be seamless and nearly immediate.
 
@@ -36,12 +36,12 @@ Here you can also explore embed options for your Haiku, which are also mirrored 
 ![](/assets/share-page.png)
 
 
-The Share Page is your entry point for sharing Haiku.  You can see and interact with your Haiku, share the link and explore embed options.
+The Share Page is your entry point for sharing Animator projects. You can see and interact with your project, share the link and explore embed options.
 
 
 #### HOW TO USE {#howtouse}
 
-The key to the Share Page is the "Get the Code" button on the bottom-right.  If you click that button, the bottom panel expands and explains exactly how to use your Haiku in a number of different codebases, including vanilla HTML (embed,) vanilla JS, React, Vue, and more.
+The key to the Share Page is the "Get the Code" button on the bottom-right.  If you click that button, the bottom panel expands and explains exactly how to use your project in a number of different codebases, including vanilla HTML (embed,) vanilla JS, React, Vue, and more.
 
 ![](/assets/share-page-get-the-code.png)
 
@@ -52,16 +52,16 @@ The key to the Share Page is the "Get the Code" button on the bottom-right.  If 
 
 From the Share Page "How to Use" menu, select the HTML Embed option, then copy and paste the snippet anywhere you'd like.  Here's an example of an HTML embed in CodePen: [https://codepen.io/anon/pen/EXQZEb](https://codepen.io/anon/pen/EXQZEb)
 
-**Tip**: To learn more about how to make your Haiku responsive please read [this help article](https://help.haiku.ai/troubleshooting-and-help/once-my-haiku-is-on-a-web-page-how-do-i-make-it-responsive) and [this section in our Docs](https://docs.haiku.ai/embedding-and-using-haiku/haiku-core-api.html#embedapi).
+**Tip**: To learn more about how to make your Animator project responsive please read [this help article](https://help.haiku.ai/troubleshooting-and-help/once-my-haiku-is-on-a-web-page-how-do-i-make-it-responsive) and [this section in our Docs](https://docs.haiku.ai/embedding-and-using-haiku/haiku-core-api.html#embedapi).
 
 
 **React Component**
 
-From the Share Page "How to Use" menu, select the React option, then **follow the instructions to install the CLI** (More info here:  [Using the Haiku CLI](../using-haiku/using-the-cli.md))
+From the Share Page "How to Use" menu, select the React option, then **follow the instructions to install the CLI** (More info here:  [Using the Haiku Animator CLI](../using-haiku/using-the-cli.md))
 
 Then from the command line, inside your React project, run `haiku install YourProjectName`.  Behind the scenes, this simply runs `npm install`, and sets up your environment to pull that component from the correct server.
 
-> _Important_: the `haiku install` command will create or modify a file called `.npmrc` in your project.  It's important that you check this into your version control, otherwise other teammates will not be able to install your Haiku components.
+> _Important_: the `haiku install` command will create or modify a file called `.npmrc` in your project.  It's important that you check this into your version control, otherwise other teammates will not be able to install your Animator components.
 
 <br>
 
@@ -71,11 +71,11 @@ Then from the command line, inside your React project, run `haiku install YourPr
 
 Forks are a unique copy of a project, which can be freely experimented on without affecting the original project. Forks can be a fun and interesting way to build upon other people's work, using their project as a starting point for your own idea.
 
-With Haiku for Mac installed, public projects can be forked by selecting **Fork this component** on their share page. Private projects cannot be forked.
+With Haiku Animator for Mac installed, public projects can be forked by selecting **Fork this component** on their share page. Private projects cannot be forked.
 
 [Read more about Public & Private projects](../using-haiku/starting-haiku.md#public--private-projects)
 
-> _Note_: Projects containing source design assets are included with projects when forked. Sketch & SVG files are bundled with Haiku projects, and Figma project URL’s are viewable but not editable (unless specified otherwise in Figma).
+> _Note_: Projects containing source design assets are included with projects when forked. Sketch & SVG files are bundled with Animator projects, and Figma project URL’s are viewable but not editable (unless specified otherwise in Figma).
 
 <br>
 
@@ -84,11 +84,11 @@ With Haiku for Mac installed, public projects can be forked by selecting **Fork 
 
 **`~/.haiku` Folder**
 
-When you open any project with Haiku on your desktop, the project files are copied to your filesystem at this location:  `~/.haiku/projects/YOUR_ORG/YOUR_PROJECT`
+When you open any project with Animator on your desktop, the project files are copied to your filesystem at this location:  `~/.haiku/projects/YOUR_ORG/YOUR_PROJECT`
 
 **`haiku clone`**
 
-You can also clone down a project directly to any location of your choosing.  You can do this with the `haiku clone YourProject` command, which uses `git clone` behind the scenes.  First, you need to install the Haiku CLI, see:  [Using the Haiku CLI](../using-haiku/using-the-cli.md)
+You can also clone down a project directly to any location of your choosing.  You can do this with the `haiku clone YourProject` command, which uses `git clone` behind the scenes.  First, you need to install the Haiku Animator CLI, see:  [Using the Haiku Animator CLI](../using-haiku/using-the-cli.md)
 
 <br>
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -1,31 +1,31 @@
 ---
-description: Get started with Haiku. Learn about Haiku, download the software for Mac, and start designing.
+description: Get started with Haiku Animator. Learn about Animator, download the software for Mac, and start designing.
 ---
 
 
 
-# Getting Started with Haiku
+# Getting Started with Haiku Animator
 <br>
 
-#### HAIKU OVERVIEW
+#### ANIMATOR OVERVIEW
 
-Haiku is a design tool for teams where you can bring your designs to life with animation and interactivity. You can then easily publish them as web-ready components. If you want to learn more about all Haiku can do go [here](/what-is-haiku.md) and if you want to get started with Haiku - read on!
+Animator is a design tool for teams where you can bring your designs to life with animation and interactivity. You can then easily publish them as web-ready components. If you want to learn more about all Animator can do go [here](/what-is-haiku.md) and if you want to get started with Animator - read on!
 
 <br>
 
-#### DOWNLOADING HAIKU
+#### DOWNLOADING ANIMATOR
 
-To download Haiku, you'll first need to create an account at [https://www.haiku.ai/](https://www.haiku.ai/).
+To download Animator, you'll first need to create an account at [https://www.haikuforteams.com/](https://www.haikuforteams.com/).
 
-Once you create your account, you will automatically be taken to the download site for Haiku.
+Once you create your account, you will automatically be taken to the download site for Animator.
 
-Please install Haiku by dragging it to your `/Applications` folder.
+Please install Animator by dragging it to your `/Applications` folder.
 
 <br>
 
 #### OTHER TOOLS
 
-Haiku  integrates with Sketch, Illustrator, and Figma. To get the most out of Haiku, you'll want to use one of these tools so you can import your designs easily into Haiku.
+Animator integrates with Sketch, Illustrator, and Figma. To get the most out of Animator, you'll want to use one of these tools so you can import your designs easily into Animator.
 
 If you don't have Sketch, you can download a free 30-day trial at [https://sketchapp.com/](https://sketchapp.com/).
 
@@ -37,9 +37,9 @@ If you don't have illustrator, you can learn more here [https://adobe.com/illust
 
 <br>
 
-#### INSTALLING THE HAIKU CLI
+#### INSTALLING THE HAIKU ANIMATOR CLI
 
-The CLI \(Command Line Interface\) is an optional part of Haiku, but it opens up a lot of powerful features — for example, you need the CLI to import a Haiku into an existing codebase, or you can use the CLI to directly clone a Haiku project to your computer, to access and edit the code manually.
+The CLI \(Command Line Interface\) is an optional part of Animator, but it opens up a lot of powerful features — for example, you need the CLI to import an Animator project into an existing codebase, or you can use the CLI to directly clone an Animator project to your computer, to access and edit the code manually.
 
 To install, run one of the following commands in your terminal:
 
@@ -52,7 +52,7 @@ OR
 
 #### START DESIGNING
 
-Now that you have Haiku downloaded you can start bringing your designs to life. Before you jump in, learn the basics with the following short intro videos (<5min each) on adding motion animation and interactivity to your Haiku projects:
+Now that you have Animator downloaded you can start bringing your designs to life. Before you jump in, learn the basics with the following short intro videos (<5min each) on adding motion animation and interactivity to your Animator projects:
 
 Click on the video below to get started with Motion Animation:
 [![Motion Animation Video](https://img.youtube.com/vi/Gs5YG_uf5UQ/0.jpg)](https://www.youtube.com/watch?v=Gs5YG_uf5UQ)
@@ -78,4 +78,4 @@ Continue to dive into our resources on the [Learn page](http://haiku.ai/learn) w
 
 
 
-[Learn More: Haiku.ai/learn](http://haiku.ai/learn) &rarr;
+[Learn More: https://www.haikuforteams.com/learn](https://www.haikuforteams.com/learn) &rarr;

--- a/help.md
+++ b/help.md
@@ -1,5 +1,5 @@
 ---
-description: The best resources for getting help with issues in Haiku, and how to get in touch.
+description: The best resources for getting help with issues in Haiku Animator, and how to get in touch.
 ---
 
 <br>
@@ -8,7 +8,7 @@ description: The best resources for getting help with issues in Haiku, and how t
 
 The best place to find information on and solutions to known issues is our [Help Center](https://help.haiku.ai/).
 
-If you run into issues not listed there, please get in touch on [our community Slack](https://www.haiku.ai/slack-community) or [by email](mailto:contact@haiku.ai).
+If you run into issues not listed there, please get in touch on [our community Slack](https://www.haikuforteams.com/slack-community) or [by email](mailto:contact@haiku.ai).
 
 Although we're a small team, we respond to messages on our Community Slack as quick as we can, and endeavor to reply to emails within 1-2 working days.
 

--- a/lessons-and-tutorials.md
+++ b/lessons-and-tutorials.md
@@ -1,16 +1,16 @@
 ---
-description: The best resources to learn how to use Haiku, including video tutorials, blog posts and more.
+description: The best resources to learn how to use Haiku Animator, including video tutorials, blog posts and more.
 ---
 
 <br>
 
 # Lessons & Tutorials
 
-We collect resources for learning how to use Haiku on our website on our [learn page](https://www.haiku.ai/learn/), including video tutorials and blog posts.
+We collect resources for learning how to use Animator on our website on our [learn page](https://www.haikuforteams.com/learn/), including video tutorials and blog posts.
 
-We always have more tutorial content planned, but if there's a topic you'd like to see us cover more in depth, let us know on [our community Slack](https://www.haiku.ai/slack-community) or [by email](mailto:contact@haiku.ai).
+We always have more tutorial content planned, but if there's a topic you'd like to see us cover more in depth, let us know on [our community Slack](https://www.haikuforteams.com/slack-community) or [by email](mailto:contact@haiku.ai).
 
 <br>
 
 
-[Next: Starting Haiku](using-haiku/starting-haiku.md) &rarr;
+[Next: Starting Haiku Animator](using-haiku/starting-haiku.md) &rarr;

--- a/using-haiku/advanced-editing-haiku-as-code.md
+++ b/using-haiku/advanced-editing-haiku-as-code.md
@@ -1,22 +1,22 @@
 ---
-description: Everything you build with Haiku is backed by simple JavaScript code. Under the hood, your Haiku is one JavaScript file on your filesystem.
+description: Everything you build with Haiku Animator is backed by simple JavaScript code. Under the hood, your Animator project is one JavaScript file on your filesystem.
 ---
 
-# Advanced:  Editing Haiku as Code
+# Advanced:  Editing Animator projects as Code
 
-Everything you build with Haiku is backed by simple JavaScript code.
+Everything you build with Animator is backed by simple JavaScript code.
 
 <br>
 
-Under the hood, your Haiku is one JavaScript file on your filesystem. You can find it in the folder that contains your project's content, e.g. `~/.haiku/projects/YOUR_ORG/YOUR_PROJECT`.
+Under the hood, your Animator project is one JavaScript file on your filesystem. You can find it in the folder that contains your project's content, e.g. `~/.haiku/projects/YOUR_ORG/YOUR_PROJECT`.
 
-The file _code/main/code.js_ (within the project folder) is the code for your Haiku. It exports a static object that you can think of as the _definition_ of your Haiku. When you embed your Haiku on a web page, the [Haiku Core](/embedding-and-using-haiku/haiku-core-api.md) transforms that definition into a dynamic UI.
+The file _code/main/code.js_ (within the project folder) is the code for your Animator project. It exports a static object that you can think of as the _definition_ of your Animator project. When you embed your Animator project on a web page, the [Haiku Core](/embedding-and-using-haiku/haiku-core-api.md) transforms that definition into a dynamic UI.
 
 <br>
 
 #### EXAMPLE CODE {#examplecode}
 
-Below is an example of the code for a simple interactive component, using Haiku's static definition format. This should look similar to the content you will see in your project's _code/main/code.js_ file.
+Below is an example of the code for a simple interactive component, using Animator's static definition format. This should look similar to the content you will see in your project's _code/main/code.js_ file.
 
 ```
 module.exports = {
@@ -70,7 +70,7 @@ Let's explore how this works.
 
 ##### template
 
-The **template** property describes the structure of your scene. Think of the template as a picture of your Haiku as a whole – including elements that may not always be visible.
+The **template** property describes the structure of your scene. Think of the template as a picture of your Animator project as a whole – including elements that may not always be visible.
 
 ```
 "elementName": "div",
@@ -84,7 +84,7 @@ Note that the _template_ is just a plain, static object. That's because adding d
 
 ##### states {#states}
 
-The **states** property describes your Haiku's internal state. States are key/descriptor pairs. The key is the name of the state, and the descriptor is an object with a `value` field. The `value` field contains the value of the state.
+The **states** property describes your project's internal state. States are key/descriptor pairs. The key is the name of the state, and the descriptor is an object with a `value` field. The `value` field contains the value of the state.
 
 ```
 "clicks": {        // <- State name
@@ -98,7 +98,7 @@ Now let's look at how to modify this state using _eventHandlers_.
 
 ##### eventHandlers {#eventHandlers}
 
-The **eventHandlers** object describes how you want your Haiku to respond to events such as UI events (e.g., a user's mouse click) and lifecycle events (e.g., the component's instantiation).
+The **eventHandlers** object describes how you want your project to respond to events such as UI events (e.g., a user's mouse click) and lifecycle events (e.g., the component's instantiation).
 
 ```
 "#box": {                           // <- CSS selector determines which elements in the template to match
@@ -109,7 +109,7 @@ The **eventHandlers** object describes how you want your Haiku to respond to eve
 
 As you can see, event listeners are just plain objects with a _handler_ property, which is a function. The parent object designates the name of the event to subscribe to. And the outermost object uses a CSS selector to designate which elements in the _template_ to listen to.
 
-Within the context of a handler function, `this` is bound to your component's instance. By mutating properties that match the names of your declared _states_ (e.g. `this.clicks = 2`), you change their state values. When those state values change, the Haiku Core knows it must re-render your Haiku.
+Within the context of a handler function, `this` is bound to your component's instance. By mutating properties that match the names of your declared _states_ (e.g. `this.clicks = 2`), you change their state values. When those state values change, the Haiku Core knows it must re-render your Animator component.
 
 <br>
 
@@ -166,7 +166,7 @@ _Expressions are one of the most powerful features in Haiku_, and we'll only scr
 
 #### FAQ {#faq}
 
-- **How do I edit my project's code?:** Just fire up a text editor and make a change to the _code/main/code.js_ file. If the Haiku app is running, your changes should appear instantly on stage.
+- **How do I edit my project's code?:** Just fire up a text editor and make a change to the _code/main/code.js_ file. If the Animator app is running, your changes should appear instantly on stage.
 
 - **Could the code.js format be nicer?** Yes. We plan to improve this in the near future. We welcome ideas for ways that it could be more concise to write and more clear to read.
 

--- a/using-haiku/advanced-version-control.md
+++ b/using-haiku/advanced-version-control.md
@@ -1,12 +1,12 @@
 ---
-description: Haiku projects, including imported assets, are backed by version control using git.  Every change made is tracked atomically as individual commits. When publishing, Haiku tags commits and pushes to our infrastructure.
+description: Haiku projects, including imported assets, are backed by version control using git.  Every change made is tracked atomically as individual commits. When publishing, Animator tags commits and pushes to our infrastructure.
 ---
 
 # Advanced:  Version Control
 
-Haiku projects, including imported assets, are backed by version control using git.
+Animator projects, including imported assets, are backed by version control using git.
 
-Every change made is tracked atomically as an individual commit. When publishing a project, Haiku tags a commit with a version number and pushes it to our infrastructure.
+Every change made is tracked atomically as an individual commit. When publishing a project, Animator tags a commit with a version number and pushes it to our infrastructure.
 
 If you’re new to git, [this blog post](http://blog.teamtreehouse.com/git-for-designers-part-1) is a good starting point.
 
@@ -14,7 +14,7 @@ If you’re new to git, [this blog post](http://blog.teamtreehouse.com/git-for-d
 
 **What's happening behind the scenes?**
 
-When you create a new project, Haiku takes care of all the hard work of setting up a git repository on your local machine and remotely on our infrastructure. In Haiku, whenever you make a change to your project or an asset, its tracked as a commit locally. Each time a project is published, its version number is incremented. Every publish attaches your version number as a tag in git, and pushes the commit to your remote repository.
+When you create a new project, Animator takes care of all the hard work of setting up a git repository on your local machine and remotely on our infrastructure. In Animator, whenever you make a change to your project or an asset, its tracked as a commit locally. Each time a project is published, its version number is incremented. Every publish attaches your version number as a tag in git, and pushes the commit to your remote repository.
 
 <br>
 
@@ -28,10 +28,10 @@ When you create a new project, Haiku takes care of all the hard work of setting 
 
 4. Enter `git reset --hard yourcommithash` pasting your commit hash from your clipboard
 
-5. Return to Haiku and continue working!
+5. Return to Animator and continue working!
 
 <br>
 
-**What are Haiku’s future plans related to version control?**
+**What are Animator's future plans related to version control?**
 
 Git provides a powerful, flexible technical foundation for version control. In the future, we plan on improving the quality of commit messages, and expose many of gits features visually to aid team collaboration between technical and non-technical users.

--- a/using-haiku/creating-an-animation.md
+++ b/using-haiku/creating-an-animation.md
@@ -1,14 +1,14 @@
 ---
-description: Animation is one of the main features of Haiku, and the heart of creating animations in Haiku is the Timeline. Using a combination of the Timeline and Stage, you can move and transform elements in your component over time, with the result being... animation!
+description: Animation is one of the main features of Haiku Animator, and the heart of creating animations in Animator is the Timeline. Using a combination of the Timeline and Stage, you can move and transform elements in your component over time, with the result being... animation!
 ---
 
 # Creating Animations with the Timeline
 
-Animation is one of the main features of Haiku, and the heart of creating animations in Haiku is the **Timeline**. Using a combination of the Timeline and Stage, you can move and transform elements in your component over time, with the result being... animation!
+Animation is one of the main features of Haiku Animator, and the heart of creating animations in Animator is the **Timeline**. Using a combination of the Timeline and Stage, you can move and transform elements in your component over time, with the result being... animation!
 
 <br>
 
-Think of it like this: While the Stage shows what each element in your Haiku _looks like_ as it animates, the Timeline depicts how the elements' _properties_ change.
+Think of it like this: While the Stage shows what each element in your project _looks like_ as it animates, the Timeline depicts how the elements' _properties_ change.
 
 The Stage is pretty self-explanatory — especially if you're familiar with a drawing tool like Sketch.
 
@@ -98,12 +98,12 @@ When you drag the timeline *ticker* left or right, you're changing the current *
 
 **Any changes you make while the ticker is at a certain position will affect the values (_keyframes_) specifically at that time.**
 
-Once you've affected values at two such points in time (i.e., created _keyframes_), you can then create a *transition* to have Haiku automatically ease between the values.  Experiment with different easing curves to finesse your animations!
+Once you've affected values at two such points in time (i.e., created _keyframes_), you can then create a *transition* to have Animator automatically ease between the values.  Experiment with different easing curves to finesse your animations!
 
 ![](/assets/animate-position.gif)
 
 > **Advanced: Animating along curves**<br>
-> While we plan to support custom, visual animation along paths in the future, there's a lot you can do with Haiku today.  Since you can animate X and Y position separately, try out *different easing curves* for each of X and Y positions.  For example, if you animate `linear` with X and `ease in > quadratic` with Y, you can plot half of a parabola (then `ease out > quadratic` with Y while continuing linearly with X to plot the other half.)  You can do the same thing with `sin`, `circ`, `bounce`, and any number of other transitions to create complex parametric path animations.
+> While we plan to support custom, visual animation along paths in the future, there's a lot you can do with Animator today.  Since you can animate X and Y position separately, try out *different easing curves* for each of X and Y positions.  For example, if you animate `linear` with X and `ease in > quadratic` with Y, you can plot half of a parabola (then `ease out > quadratic` with Y while continuing linearly with X to plot the other half.)  You can do the same thing with `sin`, `circ`, `bounce`, and any number of other transitions to create complex parametric path animations.
 
 <br>
 
@@ -113,7 +113,7 @@ If you drag an element across the stage *at a point in time*, keyframes will aut
 
 Both techniques are 'windows' into the same underlying data.
 
-In fact, both of these techniques also have exactly the same outcome as editing the values manually in the code — which you can read more about under [Advanced:  Editing Haiku as Code](./advanced-editing-haiku-as-code.md).
+In fact, both of these techniques also have exactly the same outcome as editing the values manually in the code — which you can read more about under [Advanced:  Editing Animator projects as Code](./advanced-editing-haiku-as-code.md).
 
 <br>
 
@@ -161,7 +161,7 @@ To edit the _value of a keyframe_, simply align the ticker over the keyframe, th
 
 #### CREATING OR EDITING A TRANSITION/TWEEN {#tweens}
 
-Once you've created two keyframes (there's always a keyframe at the first frame) you can create a Transition.  Haiku will then ease between the values of the two keyframes, along the Easing Curve that you specify.
+Once you've created two keyframes (there's always a keyframe at the first frame) you can create a Transition.  Animator will then ease between the values of the two keyframes, along the Easing Curve that you specify.
 
 To create a transition, right-click between two keyframes, then choose `"Create Tween" >` and select your desired curve.
 

--- a/using-haiku/defining-states.md
+++ b/using-haiku/defining-states.md
@@ -1,22 +1,22 @@
 ---
-description: Every Haiku you create can have its own collection of internal state. These pieces of data are special to your component in that you may summon them into your expression functions, allowing you to create complex dynamic behavior.
+description: Every Animator project you create can have its own collection of internal state. These pieces of data are special to your component in that you may summon them into your expression functions, allowing you to create complex dynamic behavior.
 ---
 
 # Defining States
 
-Every Haiku you create can have its own collection of internal state. These pieces of data are special to your component in that you may "summon" them into your [expression functions](/using-haiku/writing-expressions.md), allowing you to create complex dynamic behavior.
+Every Animator project you create can have its own collection of internal state. These pieces of data are special to your component in that you may "summon" them into your [expression functions](/using-haiku/writing-expressions.md), allowing you to create complex dynamic behavior.
 
 <br>
 
 #### DEFINING/EDITING STATES {#defandedit}
 
-You can manage your Haiku's state values using the State Inspector, which is accessible via a tab next to the Library:
+You can manage your project's state values using the State Inspector, which is accessible via a tab next to the Library:
 
 <div style="width: 300px; margin: 0 auto;">
   <img src="/assets/states-ui-empty.png"/>
 </div>
 
-Press the "+" button at top-right to add a new state value. In the left field, type the state name. In the right field, type the state value. Haiku will automatically infer whether your input value is a string, numeric, or a complex data type like a JSON array or object.
+Press the "+" button at top-right to add a new state value. In the left field, type the state name. In the right field, type the state value. Animator will automatically infer whether your input value is a string, numeric, or a complex data type like a JSON array or object.
 
 <div style="width: 300px; margin: 0 auto;">
   <img src="/assets/states-ui.png"/>
@@ -28,7 +28,7 @@ Press `Enter` to save the state value.
 
 #### SUMMONING STATES IN EXPRESSIONS {#summoninexpressions}
 
-To access a state value in an [expression](/using-haiku/writing-expressions.md), simply **type its name**. Haiku will automatically detect the state you are referencing, and will send its current value to your expression whenever it is evaluated.
+To access a state value in an [expression](/using-haiku/writing-expressions.md), simply **type its name**. Animator will automatically detect the state you are referencing, and will send its current value to your expression whenever it is evaluated.
 
 ![](/assets/expr-multiline-ui-0.png)
 
@@ -36,17 +36,17 @@ To access a state value in an [expression](/using-haiku/writing-expressions.md),
 
 #### CHANGING STATE VALUES {#changevalues}
 
-You're probably thinking to yourself, "States aren't very useful unless you can change them." You're right! 
+You're probably thinking to yourself, "States aren't very useful unless you can change them." You're right!
 
-There are two ways to change state: Externally and programmatically from component itself. 
+There are two ways to change state: Externally and programmatically from component itself.
 
 
 ##### Changing state externally
 
 
-Every Haiku component provides a way to change its states, available when the component is [embedded](/embedding-and-using-haiku/publishing-and-embedding.md) in production.
+Every Animator component provides a way to change its states, available when the component is [embedded](/embedding-and-using-haiku/publishing-and-embedding.md) in production.
 
-All you need to do to update states dynamically as your component animates is to pass in a new _states object_, and the new values it contains will be used in place of the ones you defined inside the Haiku app.
+All you need to do to update states dynamically as your component animates is to pass in a new _states object_, and the new values it contains will be used in place of the ones you defined inside the Animator app.
 
 <br>
 
@@ -64,7 +64,7 @@ All you need to do to update states dynamically as your component animates is to
 
 ##### Changing state programmatically
 
-Another option to change states is inside [actions](/using-haiku/actions.md), as a response to a Haiku event (eg. On frame play, mouse click, mouse hover, etc). For example, imagine user want to change previous defined `baz` to `8` when user click on some element, the action contents of `click` should be:
+Another option to change states is inside [actions](/using-haiku/actions.md), as a response to an Animator event (eg. On frame play, mouse click, mouse hover, etc). For example, imagine user want to change previous defined `baz` to `8` when user click on some element, the action contents of `click` should be:
 
 ```
 this.setState({baz: 8})

--- a/using-haiku/editing-elements-on-the-stage.md
+++ b/using-haiku/editing-elements-on-the-stage.md
@@ -1,10 +1,10 @@
 ---
-description: You can use the Haiku stage to position and transform your design elements. The first step is to get your designs on the stage. Then you can use Haiku's familiar on-stage tools to position and transform them.
+description: You can use the Animator stage to position and transform your design elements. The first step is to get your designs on the stage. Then you can use Animator's familiar on-stage tools to position and transform them.
 ---
 
 # Editing Elements on the Stage
 
-You can use the Haiku stage to position and transform your design elements. The first step is to get your designs on the stage. Then you can use Haiku's familiar on-stage tools to position and transform them.
+You can use the Animator stage to position and transform your design elements. The first step is to get your designs on the stage. Then you can use Animator's familiar on-stage tools to position and transform them.
 
 <br>
 
@@ -42,7 +42,7 @@ To *Pan*, hover over the stage with your mouse, hold the `Space Bar` and click a
 
 #### RESIZING THE STAGE {#resizestage}
 
-You can resize the stage (and thus default size for your Haiku component) in two ways:
+You can resize the stage (and thus default size for your Animator component) in two ways:
 
 Visually, you can hover over the stage name until the stage is outlined in pink — then click and you will get a visual resizing tool.
 

--- a/using-haiku/keyboard-shortcuts-and-input.md
+++ b/using-haiku/keyboard-shortcuts-and-input.md
@@ -1,11 +1,11 @@
 ---
-description: Boost your productivity with keyboard shortcuts. Haiku supports an array of keyboard shortcuts to help expedite your workflow.
+description: Boost your productivity with keyboard shortcuts. Haiku Animator supports an array of keyboard shortcuts to help expedite your workflow.
 ---
 # Keyboard shortcuts &amp; Input
 
 #### KEYBOARD SHORTCUTS {#keyboard}
 
-Haiku supports an array of keyboard shortcuts to help expedite your workflow:
+Haiku Animator supports an array of keyboard shortcuts to help expedite your workflow:
 
 | Keyboard Input (macOS) | Shortcut |
 | -- | -- |

--- a/using-haiku/reusable-components.md
+++ b/using-haiku/reusable-components.md
@@ -14,7 +14,7 @@ We have a short video tutorial available on Reusable Components that you can wat
 
 #### CREATING A COMPONENT {#create}
 
-To create a subcomponent simply highlight your desired component in Haiku and right click on it to "Create Component".
+To create a subcomponent simply highlight your desired component in Animator and right click on it to "Create Component".
 
 ![Create Component Gif](/assets/create_component.gif)
 

--- a/using-haiku/sketch-and-image-assets.md
+++ b/using-haiku/sketch-and-image-assets.md
@@ -1,12 +1,12 @@
 ---
-description: Haiku integrates with the tools you already love. Draw in Sketch, bring to life in Haiku. Let's start by covering how to get your Sketch design into Haiku.
+description: Haiku Animator integrates with the tools you already love. Draw in Sketch, bring to life in Animator. Let's start by covering how to get your Sketch design into Animator.
 ---
 
 # Sketch and Other Image Assets
 
-Haiku doesn't _yet_ provide its own drawing tools. Though we plan to add some in the future, this was an intentional decision.  Designers told us resoundingly that they don't want _yet another drawing tool_, so we simply integrated with existing ones.  Think of it this way:  **draw in your favorite drawing tool, bring to life in Haiku.**
+Animator doesn't _yet_ provide its own drawing tools. Though we plan to add some in the future, this was an intentional decision.  Designers told us resoundingly that they don't want _yet another drawing tool_, so we simply integrated with existing ones.  Think of it this way:  **draw in your favorite drawing tool, bring to life in Animator.**
 
-Let's first cover how to get your Sketch design into Haiku:
+Let's first cover how to get your Sketch design into Animator:
 
 <br>
 
@@ -32,17 +32,17 @@ This one's self-explanatory:  to get an item from the Library to the Stage, simp
 
 #### CHANGING ASSETS FROM SKETCH {#changeassets}
 
-What if you need to make a change to the Sketch file? That's fine! We'll take care of bringing your new changes into Haiku and onto any assets you've placed on the stage.
+What if you need to make a change to the Sketch file? That's fine! We'll take care of bringing your new changes into Animator and onto any assets you've placed on the stage.
 
-When you import a Sketch file, we automatically make a copy of that file and start tracking changes behind the scenes with Git.  _What this means is if you make changes to your original file, they won't show up by default in Haiku._
+When you import a Sketch file, we automatically make a copy of that file and start tracking changes behind the scenes with Git.  _What this means is if you make changes to your original file, they won't show up by default in Animator._
 
-**To make changes to your Sketch-linked assets, double-click the Sketch file in the library.**  Sketch will launch, and when you **Save** in Sketch, changes will automatically be tracked in Haiku.  Even elements already on the stage remain linked and can be updated directly from Sketch.
+**To make changes to your Sketch-linked assets, double-click the Sketch file in the library.**  Sketch will launch, and when you **Save** in Sketch, changes will automatically be tracked in Animator. Even elements already on the stage remain linked and can be updated directly from Sketch.
 
 ![](/assets/open-sketch.gif)
 
 #### Other Image Assets {#other}
 
-Haiku also supports SVG files. If you want to work with an .svg file, just click "IMPORT" in your library as we did above for a .sketch file.
+Animator also supports SVG files. If you want to work with an .svg file, just click "IMPORT" in your library as we did above for a .sketch file.
 
 If you want to work with raster assets (JPEG, PNG, etc) the best way to currently do that is to paste your asset into a .sketch file, and mark that Sketch layer for export or as a slice.
 

--- a/using-haiku/starting-haiku.md
+++ b/using-haiku/starting-haiku.md
@@ -1,14 +1,14 @@
 ---
-description: When you first open Haiku, you will be prompted to log in.  Enter the username and password you used when you created your account.  If you forgot your password, you can reset it with this link.
+description: When you first open Animator, you will be prompted to log in.  Enter the username and password you used when you created your account.  If you forgot your password, you can reset it with this link.
 ---
 
-# Starting Haiku
+# Starting Haiku Animator
 
 #### LOGGING IN {#login}
 
-When you first open Haiku, you will be prompted to log in.  Enter the username and password you used when you created your account.  If you forgot your password, you can reset your password [here](https://www.haiku.ai/account/reset-password).
+When you first open Animator, you will be prompted to log in.  Enter the username and password you used when you created your account.  If you forgot your password, you can reset your password [here](https://www.haiku.ai/account/reset-password).
 
-**Haiku CLI option:**  you can run `haiku login` to log in interactively from the command line.  You can also run `haiku logout` to log out.
+**Haiku Animator CLI option:**  you can run `haiku login` to log in interactively from the command line.  You can also run `haiku logout` to log out.
 
 <br>
 

--- a/using-haiku/summonables.md
+++ b/using-haiku/summonables.md
@@ -1,10 +1,10 @@
 ---
-description: Values you summon into expressions are called summonables. Built-in summonables are commonly-used piece of data that Haiku tracks and updates such as current mouse position or the dimensions of the viewport.
+description: Values you summon into expressions are called summonables. Built-in summonables are commonly-used piece of data that Animator tracks and updates such as current mouse position or the dimensions of the viewport.
 ---
 
 # Summonables
 
-As you may know from our sections on [expressions](/using-haiku/writing-expressions.md) and [editing Haiku as code](/using-haiku/advanced-editing-haiku-as-code.md), expression functions can summon _states_ that your component has defined.
+As you may know from our sections on [expressions](/using-haiku/writing-expressions.md) and [editing Animator projects as code](/using-haiku/advanced-editing-haiku-as-code.md), expression functions can summon _states_ that your component has defined.
 
 In general, we call any value you summon into an expression a **_summonable_**.
 
@@ -24,7 +24,7 @@ function ($user) {
 }
 ```
 
-If you are typing an expression inside the Haiku app, this function signature will be created for you automatically. All you need to do is type `$user.mouse.x` like so:
+If you are typing an expression inside the Animator app, this function signature will be created for you automatically. All you need to do is type `$user.mouse.x` like so:
 
 ![](/assets/expression-single-line-usermousex.png)
 
@@ -126,7 +126,7 @@ The following is a list of built-in summonables available to you within expressi
 
 > Note: The above list is incomplete and simplified. Also, we plan to provide many additional built-in summonables for convenience in the future.
 
-> The root names of these built-in summonables are prefixed with a dollar sign (`$`) to differentiate them from your internal states, and to make sure your Haiku's private namespace stays clean.
+> The root names of these built-in summonables are prefixed with a dollar sign (`$`) to differentiate them from your internal states, and to make sure your Animator's private namespace stays clean.
 
 <br>
 

--- a/using-haiku/using-the-cli.md
+++ b/using-haiku/using-the-cli.md
@@ -1,12 +1,12 @@
 ---
-description: The Haiku CLI is the Swiss army knife for developers using Haiku. You can use it to import a Haiku into an existing codebase (using npm install) or you can use the CLI to perform advanced operations on your local machine.
+description: The Haiku Animator CLI is the Swiss army knife for developers using Haiku. You can use it to import an Animator project into an existing codebase (using npm install) or you can use the CLI to perform advanced operations on your local machine.
 ---
 
-# Using the Haiku CLI
+# Using the Haiku Animator CLI
 
 #### OVERVIEW
 
-The Haiku CLI is the "Swiss army knife" for developers using Haiku.  You can use it to import a Haiku into an existing codebase (essentially `npm install`,) or you can use the CLI to directly clone a Haiku project to your computer, to access and edit the code manually (essentially, `git clone`.)
+The Haiku Animator CLI is the "Swiss army knife" for developers using Animator. You can use it to import an Animator project into an existing codebase (essentially `npm install`,) or you can use the CLI to directly clone an Animator project to your computer, to access and edit the code manually (essentially, `git clone`.)
 
 
 #### INSTALLATION {#installation}
@@ -26,7 +26,7 @@ To install, run the following command in your terminal:
 
 ```
 NAME:
-    haiku - The Haiku CLI — developer utilities for automating Haiku actions and performing local and server-enabled actions without requiring the desktop app.
+    haiku - The Haiku Animator CLI — developer utilities for automating Animator actions and performing local and server-enabled actions without requiring the desktop app.
 
 USAGE:
     haiku [global options] command [command options] [arguments...]
@@ -37,9 +37,9 @@ VERSION:
 COMMANDS:
     list               Lists your team projects
     change-password    Changes your Haiku account password (interactive)
-    clone              Clone a Haiku project to your filesystem, passing through to git clone
-    delete             Deletes a Haiku project for your entire team.  Cannot be undone.
-    install            Install a Haiku project as an npm module, requires a package.json
+    clone              Clone an Animator project to your filesystem, passing through to git clone
+    delete             Deletes an Animator project for your entire team.  Cannot be undone.
+    install            Install an Animator project as an npm module, requires a package.json
     login              Logs into Haiku services.  (interactive)
     logout             Logs out of Haiku services.
     update,upgrade     Updates dependencies

--- a/using-haiku/writing-expressions.md
+++ b/using-haiku/writing-expressions.md
@@ -6,9 +6,9 @@ description: Expressions are small snippets of code that add dynamic behaviour t
 
 # Writing Expressions
 
-Whether you're visually creating an animation with the [Timeline](/using-haiku/creating-an-animation.md), or [hand-editing your Haiku as code](/using-haiku/advanced-editing-haiku-as-code.md), one of the most powerful techniques you can use to bring your Haiku to life is **expressions**.
+Whether you're visually creating an animation with the [Timeline](/using-haiku/creating-an-animation.md), or [hand-editing your Animator projects as code](/using-haiku/advanced-editing-haiku-as-code.md), one of the most powerful techniques you can use to bring your Animator project to life is **expressions**.
 
-_Expressions_ are just small snippets of code that add dynamic behavior to the properties of your Haiku. To be more specific, they're really _just JavaScript functions_ that run at specific moments in time as your Haiku animates.
+_Expressions_ are just small snippets of code that add dynamic behavior to the properties of your project. To be more specific, they're really _just JavaScript functions_ that run at specific moments in time as your project animates.
 
 ![](/assets/expr-anim.gif)
 
@@ -18,7 +18,7 @@ _Expressions_ are just small snippets of code that add dynamic behavior to the p
 
 In the [Timeline guide](/using-haiku/creating-an-animation.md), we cover how to use the property inputs on the timeline to create keyframes. But those inputs can contain more than just simple values — they can also contain expressions!
 
-Just as you might write a formula with Microsoft Excel, in Haiku you can start creating an expression by **typing an _equals sign_ character**. The input field will automatically recognize that you're typing in an expression:
+Just as you might write a formula with Microsoft Excel, in Animator you can start creating an expression by **typing an _equals sign_ character**. The input field will automatically recognize that you're typing in an expression:
 
 ![](/assets/expr-00.png)
 
@@ -46,7 +46,7 @@ But where does the dynamic data come from in the first place? And how do you ref
 
 #### DYNAMIC DATA PART I: STATES {#dyanmicdatapt1}
 
-The basic kind of dynamic data in Haiku is called a _state_. You can manage your state values using the State Inspector which is accessible via a tab next to the Library:
+The basic kind of dynamic data in Animator is called a _state_. You can manage your state values using the State Inspector which is accessible via a tab next to the Library:
 
 <div style="width: 300px; margin: 0 auto;">
   <img src="/assets/states-ui.png"/>
@@ -58,7 +58,7 @@ The basic kind of dynamic data in Haiku is called a _state_. You can manage your
 
 #### SUMMONING STATES {#summonstates}
 
-To access a state value in an expression, simply **type its name**. Haiku will automatically match the word you type to the state you are referencing. Haiku will keep track of the state value and pass it to your expression whenever it is calculated.
+To access a state value in an expression, simply **type its name**. Animator will automatically match the word you type to the state you are referencing. Animator will keep track of the state value and pass it to your expression whenever it is calculated.
 
 ![](/assets/expr-ui.png)
 
@@ -68,13 +68,13 @@ If you toggle multi-line mode, you can see the entire expression function. As yo
 
 ![](/assets/expr-multiline-ui-0.png)
 
-> Note: Clearly, states aren't much use unless they can be changed! Changing your Haiku's states is covered in depth in the **[States guide](/using-haiku/defining-states.md)**.
+> Note: Clearly, states aren't much use unless they can be changed! Changing your Animator's states is covered in depth in the **[States guide](/using-haiku/defining-states.md)**.
 
 <br>
 
 #### DYNAMIC DATA PART II: BUILT-INS (#dynamicdatapt2)
 
-In addition to _states_, Haiku also provides a collection of built-in pieces of dynamic data that you can summon into your expression function, for example:
+In addition to _states_, Animator also provides a collection of built-in pieces of dynamic data that you can summon into your expression function, for example:
 
 * The user's mouse position (`$user.mouse.x` and `$user.mouse.y`)
 * The window size (`$window.width` and `$window.height`)
@@ -96,7 +96,7 @@ Just like with states, you can summon any dynamic built-in data point if you sim
 
 #### ADVANCED: EXPRESSIONS IN CODE {#advanced}
 
-Expressions that you write [manually in your code](/using-haiku/advanced-editing-haiku-as-code.md) are the same as expressions you create visually using the Haiku app. _When you write an expression in the Haiku app, it gets written to your code file as an expression function, just as if you had written it manually!_
+Expressions that you write [manually in your code](/using-haiku/advanced-editing-haiku-as-code.md) are the same as expressions you create visually using the Animator app. _When you write an expression in the Animator app, it gets written to your code file as an expression function, just as if you had written it manually!_
 
 Here's what an expression might look like if hand-written in code:
 

--- a/what-is-haiku.md
+++ b/what-is-haiku.md
@@ -1,12 +1,12 @@
 ---
-description: Haiku is a desktop app backed by cloud services for creating interactive, animated UI components. Bring your designs to life with animation, add interactivity responding to user events and data, and publish your creations as web, iOS and Android UI components.
+description: Animator is a desktop app backed by cloud services for creating interactive, animated UI components. Bring your designs to life with animation, add interactivity responding to user events and data, and publish your creations as web, iOS and Android UI components.
 ---
 
 <br>
 
-# What is Haiku?
+# What is Animator?
 
-[Haiku](https://haiku.ai) is a desktop app for Mac for creating interactive, animated UI components.
+[Animator](https://www.haikuforteams.com/) is a desktop app for Mac for creating interactive, animated UI components.
 
 <br>
 
@@ -14,13 +14,13 @@ This is what it looks like when you start a fresh project:
 
 ![](/assets/full-app.png)
 
-And this is what it might look like after you've created your Haiku:
+And this is what it might look like after you've created your Animator project:
 
 ![](/assets/full-app-populated.jpg)
 
 <br>
 
-With the Haiku app installed on your workstation, you can:
+With the Animator app installed on your workstation, you can:
 
 * Bring any Sketch design to life with animation
 * Add interactivity by responding to user events and data
@@ -29,19 +29,19 @@ With the Haiku app installed on your workstation, you can:
 
 <br>
 
-But Haiku is also a lot more than a design tool.
+But Animator is also a lot more than a design tool.
 
 <br>
 
-**Haiku is for shipping to production:** Every component you make in Haiku is automatically optimized for production — this is not a prototyping tool. We're building Haiku because we believe creative teams should spend less time making throwaway prototypes, and more time shipping.
+**Animator is for shipping to production:** Every component you make in Animator is automatically optimized for production — this is not a prototyping tool. We're building Animator because we believe creative teams should spend less time making throwaway prototypes, and more time shipping.
 
 <br>
 
-**Haiku is for engineers, too:** Under the hood, every Haiku component is clean JavaScript code that you can always hand-edit, without breaking the link to the source design. No more reworking your handcrafted code as fresh design changes come in. And we provide a [powerful API](embedding-and-using-haiku/haiku-core-api.md) for wiring up your component to external business logic.
+**Animator is for engineers, too:** Under the hood, every Animator component is clean JavaScript code that you can always hand-edit, without breaking the link to the source design. No more reworking your handcrafted code as fresh design changes come in. And we provide a [powerful API](embedding-and-using-haiku/haiku-core-api.md) for wiring up your component to external business logic.
 
 <br>
 
-**Haiku is for teams:** Every change you make in Haiku is automatically tracked in a version control system, so your work is always safe. We've taken care to make sure Haiku can integrate with a wide variety of app platforms and frameworks, so your team can try a small sample of Haiku within an existing project to see whether it's right for you. And coming soon, you can expect to see features like real-time collaborative editing, branching, sharing drafts, in-context commenting, and more.
+**Animator is for teams:** Every change you make in Animator is automatically tracked in a version control system, so your work is always safe. We've taken care to make sure Animator can integrate with a wide variety of app platforms and frameworks, so your team can try a small sample of Animator within an existing project to see whether it's right for you. And coming soon, you can expect to see features like real-time collaborative editing, branching, sharing drafts, in-context commenting, and more.
 
 <br>
 


### PR DESCRIPTION
What:

- Substitute "Haiku" for "Haiku Animator" or only "Animator" depending on the context.
- Replace URLs.
- Substitute "Haiku" for "Animator project" or only "project" depending on the context.